### PR TITLE
feat (join): link to team page for those with accounts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,7 @@ export default function slackin({
 
   // splash page
   app.get('/', (req, res) => {
+    let host = slack.host;
     let { name, logo } = slack.org;
     let { active, total } = slack.users;
     if (!name) return res.send(404);
@@ -61,7 +62,7 @@ export default function slackin({
         dom('meta name=viewport content="initial-scale=1.0,user-scalable=no"'),
         css && dom('link rel=stylesheet', { href: css })
       ),
-      splash({ css, name, logo, channel, active, total })
+      splash({ css, name, logo, channel, active, total, host })
     );
     res.type('html');
     res.send(page.toHTML());

--- a/lib/splash.js
+++ b/lib/splash.js
@@ -1,15 +1,18 @@
 
 import dom from 'vd';
 
-export default function splash({ name, logo, active, total, channel, iframe }){
+function teamUrl(host) {
+  return `https://${host}.slack.com`;
+}
+export default function splash({ name, logo, active, total, channel, iframe, host }){
   let div = dom('.splash',
     !iframe && dom('.logos',
       logo && dom('.logo.org'),
       dom('.logo.slack')
     ),
     dom('p', 
-      'Join ', dom('b', name),
-      channel && dom('span', ' #', channel),
+      'Join ', dom(`a class="community-name--link" href="${teamUrl(host)}"`, dom('b', name),
+      channel && dom('span', ' #', channel)),
       ' on Slack.'
     ),
     dom('p.status',
@@ -234,6 +237,11 @@ function style({ logo, active, iframe } = {}){
       'color': '#fff',
       'background-color': '#9B9B9B'
     });
+
+    css.add('.community-name--link', {
+      'color': '#000'
+    });
+
   }
 
   return css;


### PR DESCRIPTION
For those that have an account, lost the team url, and make it to sign up this
gives them an opportunity to return to the embercommunity slack team.

closes #1
